### PR TITLE
Fix: Flipping Opponent Piece Incorrectly (#3)

### DIFF
--- a/Othello/src/GameManager.cpp
+++ b/Othello/src/GameManager.cpp
@@ -11,18 +11,29 @@ GameManager::~GameManager() {
 }
 
 bool GameManager::StartGame() {
-  InitializePlayers();
+  InitializePlayers(true);
 
   //No player info
   if(!_player1_ptr || !_player2_ptr) return false;
 
   //_player_1 starting pieces
   InsertPlayerPieceByCoordinates("E4", _player1_ptr, true);
-  InsertPlayerPieceByCoordinates("D5", _player1_ptr, true);
+  // InsertPlayerPieceByCoordinates("D5", _player1_ptr, true);
 
   //_player_2 starting pieces
   InsertPlayerPieceByCoordinates("D4", _player2_ptr, true);
-  InsertPlayerPieceByCoordinates("E5", _player2_ptr, true);
+  // InsertPlayerPieceByCoordinates("E5", _player2_ptr, true);
+
+  InsertPlayerPieceByCoordinates("C6", _player2_ptr, true);
+  InsertPlayerPieceByCoordinates("C7", _player2_ptr, true);
+  InsertPlayerPieceByCoordinates("C8", _player2_ptr, true);
+  
+  InsertPlayerPieceByCoordinates("D5", _player2_ptr, true);
+  InsertPlayerPieceByCoordinates("E5", _player1_ptr, true);
+
+
+
+  
 
 
   _current_state = GameState::AnalyzeBoard;
@@ -398,17 +409,19 @@ std::vector<BoardCoordinateUtils::coordinates> GameManager::GetPiecesToFlipCoord
           (row >= 0 && row < BOARD_LENGTH) && (col >= 0 && col < BOARD_LENGTH);
           row += increment_row_val, col += increment_col_val) {
           char current_piece = _othello_gameboard[row][col];
+          
+
           if (current_piece == current_player_piece) return result_coordinates;
           if (current_piece == opposing_player_piece) {
+            if (row + increment_row_val < 0 || row + increment_row_val == BOARD_LENGTH) return std::vector<BoardCoordinateUtils::coordinates> {};
+            if (col + increment_col_val < 0 || col + increment_col_val == BOARD_LENGTH) return std::vector<BoardCoordinateUtils::coordinates> {};
             BoardCoordinateUtils::coordinates pieces_to_flip_coordinates;
             pieces_to_flip_coordinates.x = row; 
             pieces_to_flip_coordinates.y = col;
             result_coordinates.push_back(pieces_to_flip_coordinates);
             continue;
-            } else {
-              return std::vector<BoardCoordinateUtils::coordinates> {};
-            }
-          
+            } 
+          return std::vector<BoardCoordinateUtils::coordinates> {};
         }
 
         return result_coordinates;


### PR DESCRIPTION
* chore: remove std namespace from HelloWorld

* chore: remove Hello World

* feat: initialize Game Manager

* feat: start the game with two players

* update: refactor player 1 and player 2 to be shared pointers

* feat: place player piece at coordinate

* feat: place piece based on user input coordinates

* feat: get vector of coordinates of the current player's pieces

* feat: alternate player turns

* feat: display vertical and horizontal possible places to play

* feat: flip pieces horizontally and vertically from the newly placed piece

* feat: flip pieces diagonally and end game state.

* chore: remove some unnecessary logs

* chore: remove logs

* fix: flipping opposing player piece incorrectly if next to boundary

---------